### PR TITLE
Fix scientific floating point construction represention

### DIFF
--- a/constructor.py
+++ b/constructor.py
@@ -1217,6 +1217,8 @@ class RoundTripConstructor(SafeConstructor):
             except ValueError:
                 mantissa, exponent = value_so.split('E')
                 exp = 'E'
+            if not '.' in mantissa:
+                    mantissa = mantissa + '.0'
             if self.resolver.processing_version != (1, 2):
                 # value_s is lower case independent of input
                 if '.' not in mantissa:

--- a/representer.py
+++ b/representer.py
@@ -287,16 +287,16 @@ class SafeRepresenter(BaseRepresenter):
             value = '-.inf'
         else:
             value = repr(data).lower()
-            if getattr(self.serializer, 'use_version', None) == (1, 1):
-                if '.' not in value and 'e' in value:
-                    # Note that in some cases `repr(data)` represents a float number
-                    # without the decimal parts.  For instance:
-                    #   >>> repr(1e17)
-                    #   '1e17'
-                    # Unfortunately, this is not a valid float representation according
-                    # to the definition of the `!!float` tag in YAML 1.1.  We fix
-                    # this by adding '.0' before the 'e' symbol.
-                    value = value.replace('e', '.0e', 1)
+            # if getattr(self.serializer, 'use_version', None) == (1, 1):
+            if '.' not in value and 'e' in value:
+                # Note that in some cases `repr(data)` represents a float number
+                # without the decimal parts.  For instance:
+                #   >>> repr(1e17)
+                #   '1e17'
+                # Unfortunately, this is not a valid float representation according
+                # to the definition of the `!!float` tag in YAML 1.1.  We fix
+                # this by adding '.0' before the 'e' symbol.
+                value = value.replace('e', '.0e', 1)
         return self.represent_scalar('tag:yaml.org,2002:float', value)
 
     def represent_list(self, data):


### PR DESCRIPTION
This PR modifies the library to add decimal point to scientific floating point.

### For example:
*Now*: 
`3e-5` would be written as `3e-05`
*With changes*:
`3e-5` would be written as `3.0e-05`

These changes are needed to avoiding reading scientific floating points read as string from `yaml` which is based on `yaml 1.1`. yaml 1.1 do not regard this `!float 3e-5` as floating type. Where as `ruamel.yaml` is based on `yaml 1.2` which treats them as float

Our requirement is to be able to have a yaml file that is consistent with both both libraries 